### PR TITLE
Changes to work with python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ install:
 
 script:
 - export CURRENT_PATH=`pwd`
-- docker run -v $CURRENT_PATH:$CURRENT_PATH hepdata/hepdata-converter /bin/bash -c "cd $CURRENT_PATH && pip install -I -e .[tests] && coverage run -m unittest discover hepdata_converter_ws/testsuite 'test_*'"
-- docker run -v $CURRENT_PATH:$CURRENT_PATH hepdata/hepdata-converter /bin/bash -c "cd $CURRENT_PATH && pip install -I -e . && hepdata-converter-ws -v"
+- docker run -v $CURRENT_PATH:$CURRENT_PATH hepdata/hepdata-converter /bin/bash -c "cd $CURRENT_PATH && pip3 install -I -e .[tests] && coverage run -m unittest discover hepdata_converter_ws/testsuite 'test_*'"
+- docker run -v $CURRENT_PATH:$CURRENT_PATH hepdata/hepdata-converter /bin/bash -c "cd $CURRENT_PATH && pip3 install -I -e . && hepdata-converter-ws -v"
 
 after_success:
 - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-- '3.6'
+- '3.8'
 
 sudo: required
 
@@ -25,7 +25,7 @@ after_success:
 
 before_deploy:
 - export CURRENT_PATH=`pwd`
-- docker run -v $CURRENT_PATH:$CURRENT_PATH hepdata/hepdata-converter /bin/bash -c "cd $CURRENT_PATH && rm -rf build hepdata_converter_ws.egg-info"
+- docker run -v $CURRENT_PATH:$CURRENT_PATH hepdata/hepdata-converter /bin/bash -c "cd $CURRENT_PATH && rm -rf build hepdata_converter_ws.egg-info  hepdata_converter_ws/__pycache__ hepdata_converter_ws/*/__pycache__"
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-- '2.7'
+- '3.6'
 sudo: required
 cache:
 - docker

--- a/hepdata_converter_ws/__init__.py
+++ b/hepdata_converter_ws/__init__.py
@@ -26,7 +26,7 @@ def create_app(config_filename=None):
 
 def main():
     if '-v' in sys.argv or '--version' in sys.argv:
-        print "hepdata-converter-ws version %s" % version.__version__
+        print("hepdata-converter-ws version %s" % version.__version__)
         sys.exit()
 
     app = create_app()

--- a/hepdata_converter_ws/__init__.py
+++ b/hepdata_converter_ws/__init__.py
@@ -1,6 +1,9 @@
 # -*- encoding: utf-8 -*-
 
 from flask.app import Flask
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
+
 import sys
 import hepdata_converter_ws
 from hepdata_converter_ws import version
@@ -12,6 +15,10 @@ DEBUG = True
 SECRET_KEY = 'development key'
 USERNAME = 'admin'
 PASSWORD = 'default'
+
+sentry_sdk.init(
+    integrations=[FlaskIntegration()]
+)
 
 
 def create_app(config_filename=None):

--- a/hepdata_converter_ws/api.py
+++ b/hepdata_converter_ws/api.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-import StringIO
+from io import StringIO
 import base64
 import os
 import tarfile
@@ -28,7 +28,7 @@ def convert():
     archive_name = kwargs['options'].get('filename', 'hepdata-converter-ws-data')
     output_format = kwargs['options'].get('output_format', '')
 
-    output, os_handle = StringIO.StringIO(), None
+    output, os_handle = StringIO(), None
     if output_format.lower() in SINGLEFILE_FORMATS or 'table' in kwargs['options']:
         os_handle, tmp_output = tempfile.mkstemp()
     else:
@@ -39,7 +39,7 @@ def convert():
         conversion_input = os.path.abspath(tmp_dir)
         conversion_output = os.path.abspath(tmp_output)
 
-        with tarfile.open(mode="r:gz", fileobj=StringIO.StringIO(base64.decodestring(input_tar))) as tar:
+        with tarfile.open(mode="r:gz", fileobj=StringIO(base64.decodestring(input_tar))) as tar:
             tar.extractall(path=conversion_input)
 
         # one file - treat it as one file input format

--- a/hepdata_converter_ws/api.py
+++ b/hepdata_converter_ws/api.py
@@ -16,6 +16,11 @@ __author__ = 'Michał Szostak'
 SINGLEFILE_FORMATS = ['root', 'yoda']
 
 
+@api.route('/debug-sentry')
+def trigger_error():
+    raise Exception('Testing that Sentry picks up this error')
+
+
 @api.route('/ping', methods=['GET'])
 def ping():
     return Response('OK')

--- a/hepdata_converter_ws/api.py
+++ b/hepdata_converter_ws/api.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-from io import StringIO
+from io import BytesIO
 import base64
 import os
 import tarfile
@@ -28,7 +28,7 @@ def convert():
     archive_name = kwargs['options'].get('filename', 'hepdata-converter-ws-data')
     output_format = kwargs['options'].get('output_format', '')
 
-    output, os_handle = StringIO(), None
+    output, os_handle = BytesIO(), None
     if output_format.lower() in SINGLEFILE_FORMATS or 'table' in kwargs['options']:
         os_handle, tmp_output = tempfile.mkstemp()
     else:
@@ -39,7 +39,7 @@ def convert():
         conversion_input = os.path.abspath(tmp_dir)
         conversion_output = os.path.abspath(tmp_output)
 
-        with tarfile.open(mode="r:gz", fileobj=StringIO(base64.decodestring(input_tar))) as tar:
+        with tarfile.open(mode="r:gz", fileobj=BytesIO(base64.b64decode(input_tar))) as tar:
             tar.extractall(path=conversion_input)
 
         # one file - treat it as one file input format

--- a/hepdata_converter_ws/testsuite/__init__.py
+++ b/hepdata_converter_ws/testsuite/__init__.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 import base64
 import tarfile
-import cStringIO
+from io import StringIO
 from hepdata_converter.testsuite import _parse_path_arguments, construct_testdata_path
 
 __author__ = 'Michał Szostak'
@@ -14,7 +14,7 @@ class insert_data_as_tar_base64(object):
 
     def __call__(self, function):
         def _inner(*args, **kwargs):
-            data_stream = cStringIO.StringIO()
+            data_stream = StringIO()
             with tarfile.open(mode='w:gz', fileobj=data_stream) as data:
                 data.add(construct_testdata_path(self.sample_file_name), arcname=self.arcname)
 
@@ -32,7 +32,7 @@ class insert_data_as_tar(object):
 
     def __call__(self, function):
         def _inner(*args, **kwargs):
-            data_stream = cStringIO.StringIO()
+            data_stream = StringIO()
             with tarfile.open(mode='w:gz', fileobj=data_stream) as data:
                 data.add(construct_testdata_path(self.sample_file_name), arcname=self.arcname)
 

--- a/hepdata_converter_ws/testsuite/__init__.py
+++ b/hepdata_converter_ws/testsuite/__init__.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 import base64
 import tarfile
-from io import StringIO
+from io import BytesIO
 from hepdata_converter.testsuite import _parse_path_arguments, construct_testdata_path
 
 __author__ = 'Michał Szostak'
@@ -14,7 +14,7 @@ class insert_data_as_tar_base64(object):
 
     def __call__(self, function):
         def _inner(*args, **kwargs):
-            data_stream = StringIO()
+            data_stream = BytesIO()
             with tarfile.open(mode='w:gz', fileobj=data_stream) as data:
                 data.add(construct_testdata_path(self.sample_file_name), arcname=self.arcname)
 
@@ -32,7 +32,7 @@ class insert_data_as_tar(object):
 
     def __call__(self, function):
         def _inner(*args, **kwargs):
-            data_stream = StringIO()
+            data_stream = BytesIO()
             with tarfile.open(mode='w:gz', fileobj=data_stream) as data:
                 data.add(construct_testdata_path(self.sample_file_name), arcname=self.arcname)
 

--- a/hepdata_converter_ws/testsuite/test_server.py
+++ b/hepdata_converter_ws/testsuite/test_server.py
@@ -108,3 +108,13 @@ class HepdataConverterWSTestCase(TMPDirMixin, ExtendedTestCase):
                 headers={'content-type': 'application/json'})
 
         self.assertTrue("did not pass validation" in str(e.exception))
+
+    def test_ping(self):
+        r = self.app_client.get('/ping')
+        self.assertTrue("OK" in str(r.data))
+
+    def test_debug_sentry(self):
+        with self.assertRaises(Exception) as e:
+            r = self.app_client.get('/debug-sentry')
+
+        self.assertTrue(str(e.exception) == "Testing that Sentry picks up this error")

--- a/hepdata_converter_ws/testsuite/test_server.py
+++ b/hepdata_converter_ws/testsuite/test_server.py
@@ -27,12 +27,12 @@ class HepdataConverterWSTestCase(TMPDirMixin, ExtendedTestCase):
     def assertMultiLineAlmostEqual(self, first, second, msg=None):
         if hasattr(first, 'readlines'):
             lines = first.readlines()
-        elif isinstance(first, (str, unicode)):
+        elif isinstance(first, str):
             lines = first.split('\n')
 
         if hasattr(second, 'readlines'):
             orig_lines = second.readlines()
-        elif isinstance(second, (str, unicode)):
+        elif isinstance(second, str):
             orig_lines = second.split('\n')
 
         # Remove blank lines at end of files
@@ -43,7 +43,7 @@ class HepdataConverterWSTestCase(TMPDirMixin, ExtendedTestCase):
             orig_lines.pop()
 
         self.assertEqual(len(lines), len(orig_lines))
-        for i in xrange(len(lines)):
+        for i in range(len(lines)):
             self.assertEqual(lines[i].strip(), orig_lines[i].strip())
 
 
@@ -78,7 +78,7 @@ class HepdataConverterWSTestCase(TMPDirMixin, ExtendedTestCase):
             }),
             headers={'content-type': 'application/json'})
 
-        with tarfile.open(mode='r:gz', fileobj=cStringIO.StringIO(r.data)) as tar:
+        with tarfile.open(mode='r:gz', fileobj=BytesIO(r.data)) as tar:
             tar.extractall(path=self.current_tmp)
 
         self.assertEqual(len(os.listdir(self.current_tmp)), 1)
@@ -107,4 +107,4 @@ class HepdataConverterWSTestCase(TMPDirMixin, ExtendedTestCase):
                 }),
                 headers={'content-type': 'application/json'})
 
-        self.assertTrue("did not pass validation" in e.exception.message)
+        self.assertTrue("did not pass validation" in str(e.exception))

--- a/hepdata_converter_ws/testsuite/test_server.py
+++ b/hepdata_converter_ws/testsuite/test_server.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-import cStringIO
+from io import StringIO
 from distlib._backport import tarfile
 import os
 import tarfile
@@ -54,7 +54,7 @@ class HepdataConverterWSTestCase(TMPDirMixin, ExtendedTestCase):
                                                       'options': {'input_format': 'oldhepdata', 'output_format': 'yaml'}}),
                          headers={'content-type': 'application/json'})
 
-        with tarfile.open(mode='r:gz', fileobj=cStringIO.StringIO(r.data)) as tar:
+        with tarfile.open(mode='r:gz', fileobj=StringIO(r.data)) as tar:
             tar.extractall(path=self.current_tmp)
 
         self.assertDirsEqual(os.path.join(self.current_tmp, 'hepdata-converter-ws-data'), yaml_path)

--- a/hepdata_converter_ws/testsuite/test_server.py
+++ b/hepdata_converter_ws/testsuite/test_server.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-from io import StringIO
+from io import BytesIO
 from distlib._backport import tarfile
 import os
 import tarfile
@@ -50,11 +50,11 @@ class HepdataConverterWSTestCase(TMPDirMixin, ExtendedTestCase):
     @insert_data_as_tar_base64('oldhepdata/sample.input')
     @insert_path('oldhepdata/yaml')
     def test_convert(self, hepdata_input_tar, yaml_path):
-        r = self.app_client.get('/convert', data=json.dumps({'input': hepdata_input_tar,
+        r = self.app_client.get('/convert', data=json.dumps({'input': hepdata_input_tar.decode('utf-8'),
                                                       'options': {'input_format': 'oldhepdata', 'output_format': 'yaml'}}),
                          headers={'content-type': 'application/json'})
 
-        with tarfile.open(mode='r:gz', fileobj=StringIO(r.data)) as tar:
+        with tarfile.open(mode='r:gz', fileobj=BytesIO(r.data)) as tar:
             tar.extractall(path=self.current_tmp)
 
         self.assertDirsEqual(os.path.join(self.current_tmp, 'hepdata-converter-ws-data'), yaml_path)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     version=get_version(),
     install_requires=[
         'hepdata-converter>=0.2',
-        'flask>=1.1.1,<2'
+        'flask>=1.1.1,<2',
+        'sentry-sdk[flask]==0.15.1'
     ],
     extras_require=extras_require,
     tests_require=test_requirements,

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     name='hepdata-converter-ws',
     version=get_version(),
     install_requires=[
-        'hepdata-converter>=0.1.35,<0.2',
+        'hepdata-converter>=0.2',
         'flask>=1.1.1,<2'
     ],
     extras_require=extras_require,
@@ -48,5 +48,5 @@ setup(
     download_url='https://github.com/HEPData/hepdata-converter-ws/tarball/%s' % get_version(),
     long_description=long_description,
     long_description_content_type='text/markdown',
-    python_requires='<3'
+    python_requires='>=3.7'
 )


### PR DESCRIPTION
Requires a new pypi image of hepdata-converter once HEPData/hepdata-converter#30 has been closed.

Fixes #7.
Fixes #13.