### PR TITLE
Add support for yoda-H5

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ input: Base64 encoded tar.gz file containing hepdata-converter-ws-data entry (di
 id: str used for caching purposes (same input files have to have same ID), not implemented?
 options: dictionary with options accepted by hepdata_converter.convert function. The most important are:
          input_format: (input format identifier e.g. yaml, oldhepdata, etc.)
-         output_format: (output format identifier e.g. yaml, root, yoda, yoda1, csv, etc.)
+         output_format: (output format identifier e.g. yaml, root, yoda, yoda1, yoda.h5, csv, etc.)
          other options are dependent on the input / output format and are documented in their respective parsers / readers
          in https://github.com/HEPData/hepdata-converter
 }

--- a/hepdata_converter_ws/api.py
+++ b/hepdata_converter_ws/api.py
@@ -35,7 +35,7 @@ def convert():
 
     output, os_handle = BytesIO(), None
     if output_format.lower() in SINGLEFILE_FORMATS or 'table' in kwargs['options']:
-        os_handle, tmp_output = tempfile.mkstemp(suffix=output_format if output_format else '')
+        os_handle, tmp_output = tempfile.mkstemp(suffix='.'+output_format if output_format else '')
     else:
         tmp_output = tempfile.mkdtemp()
 

--- a/hepdata_converter_ws/api.py
+++ b/hepdata_converter_ws/api.py
@@ -13,7 +13,7 @@ api = Blueprint('api', __name__)
 
 __author__ = 'Michał Szostak'
 
-SINGLEFILE_FORMATS = ['root', 'yoda', 'yoda1']
+SINGLEFILE_FORMATS = ['root', 'yoda', 'yoda1', 'yoda.h5']
 
 
 @api.route('/debug-sentry')
@@ -35,7 +35,7 @@ def convert():
 
     output, os_handle = BytesIO(), None
     if output_format.lower() in SINGLEFILE_FORMATS or 'table' in kwargs['options']:
-        os_handle, tmp_output = tempfile.mkstemp()
+        os_handle, tmp_output = tempfile.mkstemp(suffix=output_format if output_format else '')
     else:
         tmp_output = tempfile.mkdtemp()
 

--- a/hepdata_converter_ws/version.py
+++ b/hepdata_converter_ws/version.py
@@ -2,4 +2,4 @@
 
 # this file ideally should only contain __version__ declaration, as anything else
 # may break setup.py and PyPI uploads
-__version__ = '0.3.1'
+__version__ = '0.3.2'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     name='hepdata-converter-ws',
     version=get_version(),
     install_requires=[
-        'hepdata-converter>=0.3.1',
+        'hepdata-converter>=0.3.3',
         'flask',
         'sentry-sdk[flask]',
     ],


### PR DESCRIPTION
As a follow-up to https://github.com/HEPData/hepdata-converter/pull/64, this PR adds yoda-H5 support for the hepdata converter web service. Namely the changes are
* Include `.yoda.h5` in supported file formats
* Add the file extension to the temporary files. This is required by yoda for it to differentiate between `.yoda` and `.yoda.h5` and enable it to actually write to the file stream. But I suppose it might not be a bad idea in general to use the correct file extension.

Tested locally on commit [f923a755](https://github.com/HEPData/hepdata-converter/commit/f923a755cf002ee3d3e70cd9c62db7f0ff033f9f) from hepdata-converter, but might need a new release of hepdata-converter to actually interact with a version of hepdata-converter that understands the `.yoda.h5` format when deployed.